### PR TITLE
fixed pytest to 4.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==4.3.0
 flake8
 pytest-asyncio
 tensorflow>=1.7


### PR DESCRIPTION
用了新版的pytest 就不會亂噴了

完整亂噴紀錄: https://travis-ci.com/Yoctol/serving-utils/jobs/182000440
