### PR TITLE
feat: Load balancing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,13 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-serving-utils = {editable = true, path = "."}
+serving-utils = {editable = true,path = "."}
 
 [dev-packages]
 pytest = "*"
 "flake8-config-yoctol" = ">=0.0.11"
 pytest-asyncio = "*"
+asynctest = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "99eaf8e26393c16ec59f4f14ee970007c9d74f923ed10db2518449a2c9972d55"
+            "sha256": "14ccf1f9ea1292eb4acfcac591c9be9f442c835db657065eda3999a440641071"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,90 +18,122 @@
     "default": {
         "grpcio": {
             "hashes": [
-                "sha256:03b78b4e7dcdfe3e257bb528cc93923f9cbbab6d5babf15a60d21e9a4a70b1a2",
-                "sha256:1ce0ccfbdfe84387dbcbf44adb4ae16ec7ae70e166ffab478993eb1ea1cba3ce",
-                "sha256:22e167a9406d73dd19ffe8ed6a485f17e6eac82505be8c108897f15e68badcbb",
-                "sha256:31d0aeca8d8ee2301c62c5c340e0889d653b1280d68f9fa203982cb6337b050e",
-                "sha256:44c7f99ca17ebbcc96fc54ed00b454d8313f1eac28c563098d8b901025aff941",
-                "sha256:5471444f53f9db6a1f1f11f5dbc173228881df8446380b6b98f90afb8fd8348e",
-                "sha256:561bca3b1bde6d6564306eb05848fd155136e9c3a25d2961129b1e2edba22fce",
-                "sha256:5bf58e1d2c2f55365c06e8cb5abe067b88ca2e5550fb62009c41df4b54505acf",
-                "sha256:6b7163d1e85d76b0815df63fcc310daec02b44532bb433f743142d4febcb181f",
-                "sha256:766d79cddad95f5f6020037fe60ea8b98578afdf0c59d5a60c106c1bdd886303",
-                "sha256:770b7372d5ca68308ff66d7baee53369fa5ce985f84bcb6aa1948c1f2f7b02f2",
-                "sha256:7ab178da777fc0f55b6aef5a755f99726e8e4b75e3903954df07b27059b54fcf",
-                "sha256:8078305e77c2f6649d36b24d8778096413e474d9d7892c6f92cfb589c9d71b2e",
-                "sha256:85600b63a386d860eeaa955e9335e18dd0d7e5477e9214825abf2c2884488369",
-                "sha256:857d9b939ae128be1c0c792eb885c7ff6a386b9dea899ac4b06f4d90a31f9d87",
-                "sha256:87a41630c90c179fa5c593400f30a467c498972c702f348d41e19dafeb1d319e",
-                "sha256:8805d486c6128cc0fcc8ecf16c4095d99a8693a541ef851429ab334e028a4a97",
-                "sha256:8d71b7a89c306a41ccc7741fc9409b14f5b86727455c2a1c0c7cfcb0f784e1f2",
-                "sha256:9e1b80bd65f8f160880cb4dad7f55697f6d37b2d7f251fc0c2128e811928f369",
-                "sha256:9e290c84a145ae2411ee0ec9913c41cd7500e2e7485fe93632434d84ef4fda67",
-                "sha256:9ec9f88b5bc94bd99372f27cdd53af1c92ba06717380b127733b953cfb181174",
-                "sha256:a0a02a8b4ba6deadf706d5f849539b3685b72b186a3c9ef5d43e8972ed60fb6f",
-                "sha256:a4059c59519f5940e01a071f74ae2a60ea8f6185b03d22a09d40c7959a36b16b",
-                "sha256:a6e028c2a6da2ebfa2365a5b32531d311fbfec0e3600fc27e901b64f0ff7e54e",
-                "sha256:adcdebf9f8463df4120c427cf6c9aed39258bccd03ed37b6939e7a145d64d6e0",
-                "sha256:bdec982610259d07156a58f80b8c3e69be7751a9208bc577b059c5193d087fad",
-                "sha256:cefc4d4251ffb73feb303d4b7e9d6c367cb60f2db16d259ea28b114045f965aa",
-                "sha256:d4145c8aa6afbac10ad27e408f7ce15992fe89ba5d0b4abca31c0c2729864c03",
-                "sha256:da76dc5ad719ee99de5ea28a5629ff92172cbb4a70d8a6ae3a5b7a53c7382ce1",
-                "sha256:dde2452c08ef8b6426ccab6b5b6de9f06d836d9937d6870e68153cbf8cb49348",
-                "sha256:e3d88091d2539a4868750914a6fe7b9ec50e42b913851fc1b77423b5bd918530",
-                "sha256:f9c67cfe6278499d7f83559dc6322a8bbb108e307817a3d7acbfea807b3603cc"
+                "sha256:0419ae5a45f49c7c40d9ae77ae4de9442431b7822851dfbbe56ee0eacb5e5654",
+                "sha256:1e8631eeee0fb0b4230aeb135e4890035f6ef9159c2a3555fa184468e325691a",
+                "sha256:24db2fa5438f3815a4edb7a189035051760ca6aa2b0b70a6a948b28bfc63c76b",
+                "sha256:2adb1cdb7d33e91069517b41249622710a94a1faece1fed31cd36904e4201cde",
+                "sha256:2cd51f35692b551aeb1fdeb7a256c7c558f6d78fcddff00640942d42f7aeba5f",
+                "sha256:3247834d24964589f8c2b121b40cd61319b3c2e8d744a6a82008643ef8a378b1",
+                "sha256:3433cb848b4209717722b62392e575a77a52a34d67c6730138102abc0a441685",
+                "sha256:39671b7ff77a962bd745746d9d2292c8ed227c5748f16598d16d8631d17dd7e5",
+                "sha256:40a0b8b2e6f6dd630f8b267eede2f40a848963d0f3c40b1b1f453a4a870f679e",
+                "sha256:40f9a74c7aa210b3e76eb1c9d56aa8d08722b73426a77626967019df9bbac287",
+                "sha256:423f76aa504c84cb94594fb88b8a24027c887f1c488cf58f2173f22f4fbd046c",
+                "sha256:43bd04cec72281a96eb361e1b0232f0f542b46da50bcfe72ef7e5a1b41d00cb3",
+                "sha256:43e38762635c09e24885d15e3a8e374b72d105d4178ee2cc9491855a8da9c380",
+                "sha256:4413b11c2385180d7de03add6c8845dd66692b148d36e27ec8c9ef537b2553a1",
+                "sha256:4450352a87094fd58daf468b04c65a9fa19ad11a0ac8ac7b7ff17d46f873cbc1",
+                "sha256:49ffda04a6e44de028b3b786278ac9a70043e7905c3eea29eed88b6524d53a29",
+                "sha256:4a38c4dde4c9120deef43aaabaa44f19186c98659ce554c29788c4071ab2f0a4",
+                "sha256:50b1febdfd21e2144b56a9aa226829e93a79c354ef22a4e5b013d9965e1ec0ed",
+                "sha256:559b1a3a8be7395ded2943ea6c2135d096f8cc7039d6d12127110b6496f251fe",
+                "sha256:5de86c182667ec68cf84019aa0d8ceccf01d352cdca19bf9e373725204bdbf50",
+                "sha256:5fc069bb481fe3fad0ba24d3baaf69e22dfa6cc1b63290e6dfeaf4ac1e996fb7",
+                "sha256:6a19d654da49516296515d6f65de4bbcbd734bc57913b21a610cfc45e6df3ff1",
+                "sha256:7535b3e52f498270e7877dde1c8944d6b7720e93e2e66b89c82a11447b5818f5",
+                "sha256:7c4e495bcabc308198b8962e60ca12f53b27eb8f03a21ac1d2d711d6dd9ecfca",
+                "sha256:8a8fc4a0220367cb8370cedac02272d574079ccc32bffbb34d53aaf9e38b5060",
+                "sha256:8b008515e067232838daca020d1af628bf6520c8cc338bf383284efe6d8bd083",
+                "sha256:8d1684258e1385e459418f3429e107eec5fb3d75e1f5a8c52e5946b3f329d6ea",
+                "sha256:8eb5d54b87fb561dc2e00a5c5226c33ffe8dbc13f2e4033a412bafb7b37b194d",
+                "sha256:94cdef0c61bd014bb7af495e21a1c3a369dd0399c3cd1965b1502043f5c88d94",
+                "sha256:9d9f3be69c7a5e84c3549a8c4403fa9ac7672da456863d21e390b2bbf45ccad1",
+                "sha256:9fb6fb5975a448169756da2d124a1beb38c0924ff6c0306d883b6848a9980f38",
+                "sha256:a5eaae8700b87144d7dfb475aa4675e500ff707292caba3deff41609ddc5b845",
+                "sha256:aaeac2d552772b76d24eaff67a5d2325bc5205c74c0d4f9fbe71685d4a971db2",
+                "sha256:bb611e447559b3b5665e12a7da5160c0de6876097f62bf1d23ba66911564868e",
+                "sha256:bc0d41f4eb07da8b8d3ea85e50b62f6491ab313834db86ae2345be07536a4e5a",
+                "sha256:bf51051c129b847d1bb63a9b0826346b5f52fb821b15fe5e0d5ef86f268510f5",
+                "sha256:c948c034d8997526011960db54f512756fb0b4be1b81140a15b4ef094c6594a4",
+                "sha256:d435a01334157c3b126b4ee5141401d44bdc8440993b18b05e2f267a6647f92d",
+                "sha256:d46c1f95672b73288e08cdca181e14e84c6229b5879561b7b8cfd48374e09287",
+                "sha256:d5d58309b42064228b16b0311ff715d6c6e20230e81b35e8d0c8cfa1bbdecad8",
+                "sha256:dc6e2e91365a1dd6314d615d80291159c7981928b88a4c65654e3fefac83a836",
+                "sha256:e0dfb5f7a39029a6cbec23affa923b22a2c02207960fd66f109e01d6f632c1eb",
+                "sha256:eb4bf58d381b1373bd21d50837a53953d625d1693f1b58fed12743c75d3dd321",
+                "sha256:ebb211a85248dbc396b29320273c1ffde484b898852432613e8df0164c091006",
+                "sha256:ec759ece4786ae993a5b7dc3b3dead6e9375d89a6c65dfd6860076d2eb2abe7b",
+                "sha256:f55108397a8fa164268238c3e69cc134e945d1f693572a2f05a028b8d0d2b837",
+                "sha256:f6c706866d424ff285b85a02de7bbe5ed0ace227766b2c42cbe12f3d9ea5a8aa",
+                "sha256:f8370ad332b36fbad117440faf0dd4b910e80b9c49db5648afd337abdde9a1b6"
             ],
-            "version": "==1.22.0"
+            "version": "==1.25.0"
         },
         "grpcio-tools": {
             "hashes": [
-                "sha256:0d8e85d7e62ea4e04ff75eace98dd0b53b22bd57dc1efbed0f8398db884e1cf6",
-                "sha256:160e6fd9c44a3f6c76a8c2f84014e367d41a3cae27c451406b616f9a08ba2b1f",
-                "sha256:337554658b4a4c0a6e1ee75acd6681ec45007e1d6d1975e885f92b665881e33a",
-                "sha256:36390281f31861b8b685f7e8366ff8abbcdcedf3dda7b73133be56db71d3283b",
-                "sha256:3dd362bcd1db5247760b7f8b8157abd53e47210a17df9de994f064819ba64c04",
-                "sha256:4381f3722f3c5d02626796f9db6dd0dcb75c13245ea5655b54880ab7bd239a73",
-                "sha256:4b5a5fe3e949bd03e068c05070f3cdc6a01b68323efb667199d3c67a30ef515c",
-                "sha256:4f43d03e3e1f5f7bb14b8bba35a607e35ea4589fed778b8321c97810bc0a76ac",
-                "sha256:67d1a8d71b2572250124ebdebbfac7248563bb97ab139916fb265705d1b0dbe2",
-                "sha256:6e6fab6e8e92aadb70b4167e5eadd843e8c850d97213fdf4a39f6e4d3596e6f0",
-                "sha256:75fe16b642564e47c65cf6d23362079cdbbbc5c544b59c7bc1a3a7c8865d73e3",
-                "sha256:78bc91e38fe6a6c80de084014e22365c788811773829f28621878a803dd6af48",
-                "sha256:8dde6f660e8390380e987b0661b2ced31bafa2d3dde9845bd918a007d998e7a8",
-                "sha256:928de5a03fa2664d20433d3023e512fa1f8bc0588ff3eceee33c2d93b82e0110",
-                "sha256:9a4348b0309c444e5b7bfd3a2cf38bdb354c56e5f4b966eb88b249aff46b0a4c",
-                "sha256:9af68a58dc1a339e5735425a66b0a7146114b6fbc860d1f8b74b277d151f7bf1",
-                "sha256:a3447b842ab2964a834776be0a38b93d1977887d43cb69a2ce9941388923d8a9",
-                "sha256:a83b82b39e32a3110e45a11f0df9aceacefd201c25da79a66edda60d37a9f2e6",
-                "sha256:b05de8f16752b50851cd1caa3e63a49b35f8adb3eee0cec8991b231fac0c158d",
-                "sha256:b5c0fe51a155625c9d1132ab8deb56b3015e111a6961e48aeb9dd89bd7c670ab",
-                "sha256:b659d2306dd79818b2fae0543377e199bcf656404032e24f2af53a0e5338b5c9",
-                "sha256:b688dd1d83fdb46ab84d14a0711a0033984add9717619513f21e00f1b005f986",
-                "sha256:bbe9c13774ecaf99beb39d05c3ee659771c903add0c5e7a761c79387f653f69f",
-                "sha256:c23f59a04ed9db331922e5f02425958a907a019e157f14a6b95dd0ca1bcf05a6",
-                "sha256:cf0c35fe4a8b0dc78d9bf181317d9fe9cd21a397429d9c0c01c0178cf20e4442",
-                "sha256:cfd2320a0b4233ec4b9d3ac8d19df69194548bd32473fdba366cb50930f59dc2",
-                "sha256:d5c82c63ec24f0de5151e478cabfca23afd39005b6d0ba62dccf81cf19b0ae7f",
-                "sha256:d8d3dcb3832c209c66c67bd0f62289358b2cb942a68c00ac94c2ebf6870f731e",
-                "sha256:d98ed0a731d6c4cee39e76ba0bc2225455da097f41fa11ebfa27fe3854b6cc98",
-                "sha256:dbb2dd5367bfd71a6a779f6b237de015d6e508df129a126fc2a39da8a675457b",
-                "sha256:f3c135ad51ec95667bb945be107d0176f3048e615283104bf30027fe8bc06a8e",
-                "sha256:f8d75ead0ef7d060699b6c87b11f3c54e0c4b8e24065cbd262b64d300558a420"
+                "sha256:007c075eb9611379fa8f520a1865b9afd850469495b0e4a46e1349b2dc1744ce",
+                "sha256:02ae9708bdd3f329b1abe1ee16b1d768b2dd7a036a8a57e342d08ee8ca054cec",
+                "sha256:2f10226bfea4f947de355008b14fb4711c85fc1121570833a96f0e2cd8de580f",
+                "sha256:314354c7321c84a6e176a99afe1945c933b8a38b4f837255c8decfef8d07f24e",
+                "sha256:406b530c283a2bb804a10ee97928290b0b60788cd114ddfce0faa681cccfe4b8",
+                "sha256:49e7682e505e6a1d35459dae1d8a616a08d5cfa6f05de00235aff2e15786af14",
+                "sha256:4a5c2b38078fc4b949e4e70f7e25cb80443d1ee9a648ce4223aa3c040a0d3b9b",
+                "sha256:4b40291d67a1fecb5170ed9ec32016e2ae07908a8fa143d2d37311b2bcbeb2c5",
+                "sha256:4b72b04cba6ecd1940d6eda07886f80fe71fb2e669f1095ebab58b1eb17a53fa",
+                "sha256:4cc95d5fddebb9348fafcc4c0147745882794ded7cfd5282b2aa158596c77a8a",
+                "sha256:4ce0261bd4426482a96467ed9ad8411417a6932c331a5bb35aa1907f618f34f6",
+                "sha256:5226371a2b569c62be0d0590ccff7bbb9566762f243933efbd4b695f9f108cd5",
+                "sha256:52aab4cbab10683f8830420c0b55ccdc6344702b4a0940913d71fe928dd731c9",
+                "sha256:532a19419535a92a1b621222f70d6da7624151fe69afa4a1063be56e7a2b884a",
+                "sha256:5a8d44add097e0a3a7c27e66a8ed0aa2fd561cda77381e818cf7862d4ad0f629",
+                "sha256:64f6027887e32a938f00b2344c337c6d4f7c4cf157ec2e84b1dd6b6fddad8e50",
+                "sha256:651b0441e8d8f302b44fb50397fe73dcd5e61b790533438e690055abdef3b234",
+                "sha256:67d12ec4548dd2b1f15c9e3a953c8f48d8c3441c2d8bd143fc3af95a1c041c2b",
+                "sha256:6c029341132a0e64cbd2dba1dda9a125e06a798b9ec864569afdecce626dd5d5",
+                "sha256:6e64214709f37b347875ac83cfed4e9cfd287f255dab2836521f591620412c40",
+                "sha256:6f70fc9a82a0145296358720cf24f83a657a745e8b51ec9564f4c9e678c5b872",
+                "sha256:6fb4739eb5eef051945b16b3c434d08653ea05f0313cf88495ced5d9db641745",
+                "sha256:79b5b1c172dafb0e76aa95bf572d4c7afc0bf97a1669b2228a0bc151071c4666",
+                "sha256:7d02755480cec3c0222f35397e810bfaf4cf9f2bf2e626f7f6efc1d40fffb7fa",
+                "sha256:818f2b8168760cf16e66fe85894a37afcff5378a64939549663a371216618498",
+                "sha256:834564c2fba02c31179af081bd80aada8dfdcca52c80e241353f6063b6154bd2",
+                "sha256:8b17347a90a14386641ffe57743bbb01a16a7149c95905364d3c8091ad377bd8",
+                "sha256:902e13dbaca9733e4668928967b301526197ecffacb8c7a0acc0c7045de8836f",
+                "sha256:988014c714ca654b3b7ca9f4dabfe487b00e023bfdd9eaf1bb0fed82bf8c4255",
+                "sha256:9a83d39e198cbed5d093f43790b92945ab74140357ec00e53ae13b421489ffb7",
+                "sha256:ac7649cff7354d2f04ebe2872f786a1d07547deded61f3d39036ebb569de91bc",
+                "sha256:b013d93bc6dc5c7bf3642bf30e673daee46f9a4984fbd9588a9cda1071278414",
+                "sha256:b02701d40f1ccf16bc8c46f56bdbf89e03110bd8fd570c854e72299ce2920c35",
+                "sha256:b0ef0da2eec959def8ba508b2a763c492f1fb989446a422d1456ac17dc1b19f4",
+                "sha256:bb8264ccf8ff904a1a396dc757ac1560b24f270b90e7dabb0ae3f637cb351bb3",
+                "sha256:bbfb58f5c0aa27b599141bb5eacaf8116b55ad89bc5a2c3afd5e965d840ad341",
+                "sha256:c1a482fdd8952a7f0098f78161a4deef8a500e54babef302548cd9f1e326d42c",
+                "sha256:c40efc662fa037898488e31756242af68a8ab5729f939bc8c9ba259bc32e7d6a",
+                "sha256:c5ad07adae3fe62761bc662c554c2734203f0f700616fc58138b852a7ef5e40e",
+                "sha256:c765512cb5cb4afaf652837b8cc69229dee14c8e92f15a6ea0f4dfd646902dd2",
+                "sha256:c871f5a89012ae44d9233305d74dfdd2059a78f0cb0303d38a4b6a562c6f9ba7",
+                "sha256:cc950fb17c1172d0c0129e8c6e787206e7ef8c24a8e39005f8cc297e9faa4f9a",
+                "sha256:d3619b43009a5c82cb7ef11847518236140d7ffdcc6600e1a151b8b49350693a",
+                "sha256:dc17a8a8b39cb37380d927d4669882af4ccc7d3ee298a15a3004f4b18ecd2ac3",
+                "sha256:eab3684ce9dec3a934a36ba79e8435210d07c50906425ab157eeb4b14503a925",
+                "sha256:f258b32dffd27ef1eb5f5f01ebb115dfad07677b0510b41f786c511a62ded033",
+                "sha256:f550c94728b67a7eeddc35b03c99552f2d7aac09c52935ad4b0552d0843fd03c",
+                "sha256:f7fc690a517c8f3765796ed005bb3273895a985a8593977291bad24568e018e3"
             ],
-            "version": "==1.22.0"
+            "version": "==1.25.0"
         },
         "grpclib": {
             "hashes": [
-                "sha256:700e0d56ff7cb7a492da3c2f743ed0b996492e5fe89ed928e484fd8cc4ba83f0"
+                "sha256:d19e2ea87cb073e5b0825dfee15336fd2b1c09278d271816e04c90faddc107ea"
             ],
-            "version": "==0.2.5"
+            "version": "==0.3.0"
         },
         "h2": {
             "hashes": [
-                "sha256:c8f387e0e4878904d4978cd688a3195f6b169d49b1ffa572a3d347d7adc5e09f",
-                "sha256:fd07e865a3272ac6ef195d8904de92dc7b38dc28297ec39cfa22716b6d62e6eb"
+                "sha256:ac377fcf586314ef3177bfd90c12c7826ab0840edeb03f0f24f511858326049e",
+                "sha256:b8a32bd282594424c0ac55845377eea13fa54fe4a8db012f3a198ed923dc3ab4"
             ],
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "hpack": {
             "hashes": [
@@ -153,54 +185,50 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0778076e764e146d3078b17c24c4d89e0ecd4ac5401beff8e1c87879043a0633",
-                "sha256:141c7102f20abe6cf0d54c4ced8d565b86df4d3077ba2343b61a6db996cefec7",
-                "sha256:14270a1ee8917d11e7753fb54fc7ffd1934f4d529235beec0b275e2ccf00333b",
-                "sha256:27e11c7a8ec9d5838bc59f809bfa86efc8a4fd02e58960fa9c49d998e14332d5",
-                "sha256:2a04dda79606f3d2f760384c38ccd3d5b9bb79d4c8126b67aff5eb09a253763e",
-                "sha256:3c26010c1b51e1224a3ca6b8df807de6e95128b0908c7e34f190e7775455b0ca",
-                "sha256:52c40f1a4262c896420c6ea1c6fda62cf67070e3947e3307f5562bd783a90336",
-                "sha256:6e4f8d9e8aa79321657079b9ac03f3cf3fd067bf31c1cca4f56d49543f4356a5",
-                "sha256:7242be12a58fec245ee9734e625964b97cf7e3f2f7d016603f9e56660ce479c7",
-                "sha256:7dc253b542bfd4b4eb88d9dbae4ca079e7bf2e2afd819ee18891a43db66c60c7",
-                "sha256:94f5bd885f67bbb25c82d80184abbf7ce4f6c3c3a41fbaa4182f034bba803e69",
-                "sha256:a89e188daa119ffa0d03ce5123dee3f8ffd5115c896c2a9d4f0dbb3d8b95bfa3",
-                "sha256:ad3399da9b0ca36e2f24de72f67ab2854a62e623274607e37e0ce5f5d5fa9166",
-                "sha256:b0348be89275fd1d4c44ffa39530c41a21062f52299b1e3ee7d1c61f060044b8",
-                "sha256:b5554368e4ede1856121b0dfa35ce71768102e4aa55e526cb8de7f374ff78722",
-                "sha256:cbddc56b2502d3f87fda4f98d948eb5b11f36ff3902e17cb6cc44727f2200525",
-                "sha256:d79f18f41751725c56eceab2a886f021d70fd70a6188fd386e29a045945ffc10",
-                "sha256:dc2ca26a19ab32dc475dbad9dfe723d3a64c835f4c23f625c2b6566ca32b9f29",
-                "sha256:dd9bcd4f294eb0633bb33d1a74febdd2b9018b8b8ed325f861fffcd2c7660bb8",
-                "sha256:e8baab1bc7c9152715844f1faca6744f2416929de10d7639ed49555a85549f52",
-                "sha256:ec31fe12668af687b99acf1567399632a7c47b0e17cfb9ae47c098644ef36797",
-                "sha256:f12b4f7e2d8f9da3141564e6737d79016fe5336cc92de6814eba579744f65b0a",
-                "sha256:f58ac38d5ca045a377b3b377c84df8175ab992c970a53332fa8ac2373df44ff7"
+                "sha256:0b0dd8f47fb177d00fa6ef2d58783c4f41ad3126b139c91dd2f7c4b3fdf5e9a5",
+                "sha256:25ffe71f96878e1da7e014467e19e7db90ae7d4e12affbc73101bcf61785214e",
+                "sha256:26efd7f7d755e6ca966a5c0ac5a930a87dbbaab1c51716ac26a38f42ecc9bc4b",
+                "sha256:28b1180c758abf34a5c3fea76fcee66a87def1656724c42bb14a6f9717a5bdf7",
+                "sha256:2e418f0a59473dac424f888dd57e85f77502a593b207809211c76e5396ae4f5c",
+                "sha256:30c84e3a62cfcb9e3066f25226e131451312a044f1fe2040e69ce792cb7de418",
+                "sha256:4650d94bb9c947151737ee022b934b7d9a845a7c76e476f3e460f09a0c8c6f39",
+                "sha256:4dd830a11e8724c9c9379feed1d1be43113f8bcce55f47ea7186d3946769ce26",
+                "sha256:4f2a2b279efde194877aff1f76cf61c68e840db242a5c7169f1ff0fd59a2b1e2",
+                "sha256:62d22566b3e3428dfc9ec972014c38ed9a4db4f8969c78f5414012ccd80a149e",
+                "sha256:669795516d62f38845c7033679c648903200980d68935baaa17ac5c7ae03ae0c",
+                "sha256:75fcd60d682db3e1f8fbe2b8b0c6761937ad56d01c1dc73edf4ef2748d5b6bc4",
+                "sha256:9395b0a41e8b7e9a284e3be7060db9d14ad80273841c952c83a5afc241d2bd98",
+                "sha256:9e37c35fc4e9410093b04a77d11a34c64bf658565e30df7cbe882056088a91c1",
+                "sha256:a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e",
+                "sha256:b46554ad4dafb2927f88de5a1d207398c5385edbb5c84d30b3ef187c4a3894d8",
+                "sha256:c867eeccd934920a800f65c6068acdd6b87e80d45cd8c8beefff783b23cdc462",
+                "sha256:dd0667f5be56fb1b570154c2c0516a528e02d50da121bbbb2cbb0b6f87f59bc2",
+                "sha256:de2b1c20494bdf47f0160bd88ed05f5e48ae5dc336b8de7cfade71abcc95c0b9",
+                "sha256:f1df7b2b7740dd777571c732f98adb5aad5450aee32772f1b39249c8a50386f6",
+                "sha256:ffca69e29079f7880c5392bf675eb8b4146479d976ae1924d01cd92b04cccbcc"
             ],
-            "version": "==1.16.4"
+            "version": "==1.17.3"
         },
         "protobuf": {
             "hashes": [
-                "sha256:05c36022fef3c7d3562ac22402965c0c2b9fe8421f459bb377323598996e407f",
-                "sha256:139b7eadcca0a861d60b523cb37d9475505e0dfb07972436b15407c2b968d87e",
-                "sha256:15f683006cb77fb849b1f561e509b03dd2b7dcc749086b8dd1831090d0ba4740",
-                "sha256:2ad566b7b7cdd8717c7af1825e19f09e8fef2787b77fcb979588944657679604",
-                "sha256:35cfcf97642ef62108e10a9431c77733ec7eaab8e32fe4653de20403429907cb",
-                "sha256:387822859ecdd012fdc25ec879f7f487da6e1d5b1ae6115e227e6be208836f71",
-                "sha256:4df14cbe1e7134afcfdbb9f058949e31c466de27d9b2f7fb4da9e0b67231b538",
-                "sha256:586c4ca37a7146d4822c700059f150ac3445ce0aef6f3ea258640838bb892dc2",
-                "sha256:58b11e530e954d29ab3180c48dc558a409f705bf16739fd4e0d3e07924ad7add",
-                "sha256:63c8c98ccb8c95f41c18fb829aeeab21c6249adee4ed75354125bdc44488f30e",
-                "sha256:72edcbacd0c73eef507d2ff1af99a6c27df18e66a3ff4351e401182e4de62b03",
-                "sha256:83dc8a561b3b954fd7002c690bb83278b8d1742a1e28abba9aaef28b0c8b437d",
-                "sha256:913171ecc84c2726b86574e40549a0ea619d569657c5a5ff782a3be7d81401a5",
-                "sha256:aabb7c741d3416671c3e6fe7c52970a226e6a8274417a97d7d795f953fadef36",
-                "sha256:b3452bbda12b1cbe2187d416779de07b2ab4c497d83a050e43c344778763721d",
-                "sha256:c5d5b8d4a9212338297fa1fa44589f69b470c0ba1d38168b432d577176b386a8",
-                "sha256:d86ee389c2c4fc3cebabb8ce83a8e97b6b3b5dc727b7419c1ccdc7b6e545a233",
-                "sha256:f2db8c754de788ab8be5e108e1e967c774c0942342b4f8aaaf14063889a6cfdc"
+                "sha256:125713564d8cfed7610e52444c9769b8dcb0b55e25cc7841f2290ee7bc86636f",
+                "sha256:1accdb7a47e51503be64d9a57543964ba674edac103215576399d2d0e34eac77",
+                "sha256:27003d12d4f68e3cbea9eb67427cab3bfddd47ff90670cb367fcd7a3a89b9657",
+                "sha256:3264f3c431a631b0b31e9db2ae8c927b79fc1a7b1b06b31e8e5bcf2af91fe896",
+                "sha256:3c5ab0f5c71ca5af27143e60613729e3488bb45f6d3f143dc918a20af8bab0bf",
+                "sha256:45dcf8758873e3f69feab075e5f3177270739f146255225474ee0b90429adef6",
+                "sha256:56a77d61a91186cc5676d8e11b36a5feb513873e4ae88d2ee5cf530d52bbcd3b",
+                "sha256:5984e4947bbcef5bd849d6244aec507d31786f2dd3344139adc1489fb403b300",
+                "sha256:6b0441da73796dd00821763bb4119674eaf252776beb50ae3883bed179a60b2a",
+                "sha256:6f6677c5ade94d4fe75a912926d6796d5c71a2a90c2aeefe0d6f211d75c74789",
+                "sha256:84a825a9418d7196e2acc48f8746cf1ee75877ed2f30433ab92a133f3eaf8fbe",
+                "sha256:b842c34fe043ccf78b4a6cf1019d7b80113707d68c88842d061fa2b8fb6ddedc",
+                "sha256:ca33d2f09dae149a1dcf942d2d825ebb06343b77b437198c9e2ef115cf5d5bc1",
+                "sha256:db83b5c12c0cd30150bb568e6feb2435c49ce4e68fe2d7b903113f0e221e58fe",
+                "sha256:f50f3b1c5c1c1334ca7ce9cad5992f098f460ffd6388a3cabad10b66c2006b09",
+                "sha256:f99f127909731cafb841c52f9216e447d3e4afb99b17bebfad327a75aee206de"
             ],
-            "version": "==3.9.0"
+            "version": "==3.10.0"
         },
         "serving-utils": {
             "editable": true,
@@ -208,13 +236,21 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         }
     },
     "develop": {
+        "asynctest": {
+            "hashes": [
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
+            ],
+            "index": "pypi",
+            "version": "==0.13.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -224,10 +260,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.1.0"
+            "version": "==19.3.0"
         },
         "entrypoints": {
             "hashes": [
@@ -238,18 +274,18 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "flake8-bugbear": {
             "hashes": [
-                "sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb",
-                "sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d"
+                "sha256:d8c466ea79d5020cb20bf9f11cf349026e09517a42264f313d3f6fddb83e0571",
+                "sha256:ded4d282778969b5ab5530ceba7aa1a9f1b86fa7618fc96a19a1d512331640f8"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==19.3.0"
+            "version": "==19.8.0"
         },
         "flake8-builtins": {
             "hashes": [
@@ -283,22 +319,23 @@
         },
         "flake8-debugger": {
             "hashes": [
-                "sha256:be4fb88de3ee8f6dd5053a2d347e2c0a2b54bab6733a2280bb20ebd3c4ca1d97"
+                "sha256:712d7c1ff69ddf3f0130e94cc88c2519e720760bce45e8c330bfdcb61ab4090d"
             ],
-            "version": "==3.1.0"
+            "version": "==3.2.1"
         },
         "flake8-print": {
             "hashes": [
-                "sha256:5010e6c138b63b62400da4b06afa33becc5e08bd1fcce9af3752445cf3342f54"
+                "sha256:324f9e59a522518daa2461bacd7f82da3c34eb26a4314c2a54bd493f8b394a68"
             ],
-            "version": "==3.1.0"
+            "version": "==3.1.4"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
-                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
-            "version": "==0.18"
+            "markers": "python_version < '3.8'",
+            "version": "==0.23"
         },
         "mccabe": {
             "hashes": [
@@ -309,24 +346,24 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
-                "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
             ],
-            "version": "==7.1.0"
+            "version": "==7.2.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
-                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
             ],
-            "version": "==19.0"
+            "version": "==19.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -351,18 +388,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
-                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+                "sha256:4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1",
+                "sha256:61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"
             ],
-            "version": "==2.4.0"
+            "version": "==2.4.4"
         },
         "pytest": {
             "hashes": [
-                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
-                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
+                "sha256:27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6",
+                "sha256:58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"
             ],
             "index": "pypi",
-            "version": "==5.0.1"
+            "version": "==5.2.2"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -374,10 +411,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "wcwidth": {
             "hashes": [
@@ -388,10 +425,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     }
 }

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -48,7 +48,8 @@ class Client:
         """Constructor.
 
         Args:
-            addr (str) : address of your serving
+            host (str) : hostname of your serving
+            port (int) : port of your serving
             pem: credentials of grpc
             channel+options: An optional list of key-value pairs (channel args in gRPC runtime)
             loop: asyncio event loop

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -37,7 +37,8 @@ class Client:
 
     def __init__(
             self,
-            addr: str,
+            host: str,
+            port: int,
             pem: str = None,
             channel_options: dict = None,
             loop: asyncio.AbstractEventLoop = None,
@@ -55,7 +56,7 @@ class Client:
             standalone_pool_for_streaming: create a new thread pool (with 1 thread)
                 for each streaming method
         """
-        self.addr = addr
+        self.addr = f"{host}:{port}"
         if channel_options is None:
             channel_options = {}
         if pem is None:
@@ -66,10 +67,6 @@ class Client:
 
         if loop is None:
             loop = asyncio.get_event_loop()
-
-        split_addr = addr.split(':')
-        host = split_addr[0]
-        port = split_addr[1]
 
         _, _, addrlist = socket.gethostbyname_ex(host)
         channels = []

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -85,6 +85,9 @@ class Connection:
 class EmptyPool(Exception):
     pass
 
+class RetryFailed(Exception):
+    pass
+
 
 class Client:
 
@@ -139,7 +142,7 @@ class Client:
 
         _, _, current_addrs = socket.gethostbyname_ex(host)
         current_addrs = set(current_addrs)
-        original_addrs = self._pool.keys()
+        original_addrs = set(self._pool.keys())
         if original_addrs == current_addrs:
             return
 
@@ -208,6 +211,8 @@ class Client:
             model_signature_name: str = None,
         ):
 
+        self._setup_connections()
+
         request = self._predict_request(
             data=data,
             output_names=output_names,
@@ -228,6 +233,8 @@ class Client:
                 self._setup_connections()
             else:
                 break
+        else:
+            raise RetryFailed()
         return self.parse_predict_response(response)
 
     async def async_predict(
@@ -237,6 +244,8 @@ class Client:
             model_name: str = 'default',
             model_signature_name: str = None,
         ):
+
+        self._setup_connections()
 
         request = self._predict_request(
             data=data,
@@ -257,5 +266,7 @@ class Client:
                 self._setup_connections()
             else:
                 break
+        else:
+            raise RetryFailed()
 
         return self.parse_predict_response(response)

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -39,13 +39,14 @@ class Connection:
     TIMEOUT_SECONDS = 5
 
     def __init__(
-        self,
-        addr: str,
-        port: int,
-        pem: str = None,
-        channel_options: dict = None,
-        loop: asyncio.AbstractEventLoop = None,
-    ):
+            self,
+            addr: str,
+            port: int,
+            pem: str = None,
+            channel_options: dict = None,
+            loop: asyncio.AbstractEventLoop = None,
+        ):
+
         self.addr = addr
         self.port = port
 

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -97,8 +97,9 @@ class Client:
             time.sleep(1)
             req = predict_pb2.PredictRequest()
             req.model_spec.name = 'intentionally_missing_model'
+            stub = self.get_round_robin_stub(is_async_stub=False)
             try:
-                self._stub.Predict(req, self.TIMEOUT_SECONDS)
+                stub.Predict(req, self.TIMEOUT_SECONDS)
             except Exception as e:
                 _code = e._state.code
                 if _code == grpc.StatusCode.UNAVAILABLE:

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -85,6 +85,7 @@ class Connection:
 class EmptyPool(Exception):
     pass
 
+
 class RetryFailed(Exception):
     pass
 

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -224,12 +224,9 @@ class Client:
 
             try:
                 stub = self.get_round_robin_stub(is_async_stub=False)
+                response = stub.Predict(request)
             except EmptyPool:
                 self._setup_connections()
-                continue
-
-            try:
-                response = stub.Predict(request)
             except Exception:
                 self._setup_connections()
             else:
@@ -255,14 +252,12 @@ class Client:
             model_signature_name=model_signature_name,
         )
         for _ in range(self.n_trys):
-            try:
-                stub = self.get_round_robin_stub(is_async_stub=True)
-            except EmptyPool:
-                self._setup_connections()
-                continue
 
             try:
+                stub = self.get_round_robin_stub(is_async_stub=True)
                 response = await stub.Predict(request)
+            except EmptyPool:
+                self._setup_connections()
             except Exception:
                 self._setup_connections()
             else:

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -1,11 +1,9 @@
 from functools import partial
 import socket
 from typing import List
-import time
 
 import asyncio
 from collections import namedtuple
-from concurrent.futures import ThreadPoolExecutor
 
 import grpc
 from grpclib.client import Channel

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -91,7 +91,10 @@ class Client:
             channel_options: dict = None,
             loop: asyncio.AbstractEventLoop = None,
         ):
-        """Constructor.
+        """Client to tensorflow_model_server or pyserving
+
+        Includes round-robin load balancing. Separate GRPC connections (channels)
+        will be made to each IP address returned by the name resolution request for `host`.
 
         Args:
             host (str) : hostname of your serving

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -83,8 +83,6 @@ class Connection:
 
 class Client:
 
-    TIMEOUT_SECONDS = 5
-
     def __init__(
             self,
             host: str,
@@ -92,8 +90,6 @@ class Client:
             pem: str = None,
             channel_options: dict = None,
             loop: asyncio.AbstractEventLoop = None,
-            executor: ThreadPoolExecutor = None,
-            standalone_pool_for_streaming: bool = False,
         ):
         """Constructor.
 
@@ -103,9 +99,6 @@ class Client:
             pem: credentials of grpc
             channel_options: An optional list of key-value pairs (channel args in gRPC runtime)
             loop: asyncio event loop
-            executor: a thread pool, or None to use the default pool of the loop
-            standalone_pool_for_streaming: create a new thread pool (with 1 thread)
-                for each streaming method
         """
         self.addr = f"{host}:{port}"
         self._pem = pem

--- a/serving_utils/round_robin_map.py
+++ b/serving_utils/round_robin_map.py
@@ -41,3 +41,6 @@ class RoundRobinMap(collections.abc.MutableMapping):
                 self._list.pop(i)
                 break
         self._list.insert(0, (k, v))
+
+    def keys(self):
+        return {k for (k, _) in self._list}

--- a/serving_utils/round_robin_map.py
+++ b/serving_utils/round_robin_map.py
@@ -1,0 +1,43 @@
+import collections
+
+
+class RoundRobinMap(collections.abc.MutableMapping):
+
+    def __init__(self):
+        self._list = []
+
+    def __delitem__(self, k):
+        for i, (key, _) in enumerate(self._list):
+            if key == k:
+                self._list.pop(i)
+                return
+        else:
+            return
+
+    def __getitem__(self, k):
+
+        for i, (key, val) in enumerate(self._list):
+            if key == k:
+                self._list.pop(i)
+                self._list.append((key, val))
+                return val
+        else:
+            raise KeyError(k)
+
+    def __iter__(self):
+        if not self._list:
+            raise StopIteration
+
+        k, v = self._list.pop(0)
+        self._list.append((k, v))
+        yield (k, v)
+
+    def __len__(self):
+        return len(self._list)
+
+    def __setitem__(self, k, v):
+        for i, (key, _) in enumerate(self._list):
+            if key == k:
+                self._list.pop(i)
+                break
+        self._list.insert(0, (k, v))

--- a/serving_utils/round_robin_map.py
+++ b/serving_utils/round_robin_map.py
@@ -5,42 +5,31 @@ class RoundRobinMap(collections.abc.MutableMapping):
 
     def __init__(self):
         self._list = []
+        self._container = collections.OrderedDict()
 
     def __delitem__(self, k):
-        for i, (key, _) in enumerate(self._list):
-            if key == k:
-                self._list.pop(i)
-                return
-        else:
-            return
+        del self._container[k]
 
     def __getitem__(self, k):
-
-        for i, (key, val) in enumerate(self._list):
-            if key == k:
-                self._list.pop(i)
-                self._list.append((key, val))
-                return val
-        else:
-            raise KeyError(k)
+        v = self._container[k]
+        self._container.move_to_end(k)
+        return v
 
     def __iter__(self):
-        if not self._list:
+        if not self._container:
             raise StopIteration
 
-        k, v = self._list.pop(0)
-        self._list.append((k, v))
-        yield (k, v)
+        first_key = next(iter(self._container))
+        v = self._container[first_key]
+        self._container.move_to_end(first_key)
+        yield (first_key, v)
 
     def __len__(self):
-        return len(self._list)
+        return len(self._container)
 
     def __setitem__(self, k, v):
-        for i, (key, _) in enumerate(self._list):
-            if key == k:
-                self._list.pop(i)
-                break
-        self._list.insert(0, (k, v))
+        self._container[k] = v
+        self._container.move_to_end(k, last=False)
 
     def keys(self):
-        return {k for (k, _) in self._list}
+        return self._container.keys()

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -1,7 +1,12 @@
+import asyncio as aio
+import random
+
 import pytest
 from unittest import mock
 from asynctest import CoroutineMock
 from unittest.mock import patch
+from grpclib.exceptions import GRPCError
+from grpclib.const import Status
 from ..client import Client
 
 import numpy as np
@@ -147,3 +152,135 @@ async def test_load_balancing():
 
             assert created_stubs[0].Predict.call_count == 1
             assert created_async_stubs[1].Predict.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_server_reset_handling():
+
+    created_grpc_channels = []
+    created_grpclib_channels = []
+    created_stubs = []
+    created_async_stubs = []
+
+    def assert_n_unique_mocks(mocks, attr, n):
+        assert len(mocks) == n
+        s = set(getattr(m, attr) for m in mocks)
+        print(s)
+        assert len(s) == n
+
+    def create_a_fake_grpclib_channel(addr, port, loop):
+        m = mock.MagicMock(name=f"{addr}:{port}")
+        m.addr = addr
+        created_grpclib_channels.append(m)
+        return m
+
+    def create_a_fake_grpc_channel(target, *_, **__):
+        m = mock.MagicMock(name=target)
+        m.target = target
+        created_grpc_channels.append(m)
+        return m
+
+    def create_a_fake_async_stub(mock_channel):
+        m = mock.MagicMock(name=f"async stub channel={mock_channel}")
+        m.channel = mock_channel
+        m.Predict = CoroutineMock()
+        created_async_stubs.append(m)
+        return m
+
+    def create_a_fake_stub(mock_channel):
+        m = mock.MagicMock(name=f"stub channel={mock_channel}")
+        m.channel = mock_channel
+        created_stubs.append(m)
+        return m
+
+    def clear_created():
+        created_grpc_channels.clear()
+        created_grpclib_channels.clear()
+        created_stubs.clear()
+        created_async_stubs.clear()
+
+    def mock_host_reset(mock_gethostbyname_ex, new_addr_list):
+        mock_gethostbyname_ex.side_effect = lambda _: ('localhost', [], new_addr_list.copy())
+        for stub in created_stubs:
+            stub.Predict.side_effect = GRPCError(Status.UNAVAILABLE)
+        for stub in created_async_stubs:
+            stub.Predict.side_effect = GRPCError(Status.UNAVAILABLE)
+
+    def assert_n_connections(c, n):
+        assert_n_unique_mocks(c._channels, 'target', n)
+        assert_n_unique_mocks(c._async_channels, 'addr', n)
+        assert_n_unique_mocks(c._stubs, 'channel', n)
+        assert_n_unique_mocks(c._async_stubs, 'channel', n)
+
+    with patch('socket.gethostbyname_ex') as mock_gethostbyname_ex:
+        with patch('serving_utils.client.Channel',
+                   side_effect=create_a_fake_grpclib_channel), \
+            patch('serving_utils.client.grpc.secure_channel',
+                  side_effect=create_a_fake_grpc_channel), \
+            patch('serving_utils.client.grpc.insecure_channel',
+                  side_effect=create_a_fake_grpc_channel), \
+            patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_async_stub), \
+            patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_stub), \
+            patch.object(Client,
+                         '_check_address_health'):
+
+            # Case: Host name resolves to 0 IP addresses
+            mock_host_reset(mock_gethostbyname_ex, [])
+
+            c = Client(host='localhost', port=9999)
+            assert_n_connections(c, 0)
+
+            mock_host_reset(mock_gethostbyname_ex, ['1.2.3.4'])
+
+            await client_async_predict(c)
+            assert_n_connections(c, 1)
+
+            mock_host_reset(mock_gethostbyname_ex, ['5.6.7.8'])
+
+            await client_async_predict(c)
+            assert_n_connections(c, 1)
+
+            mock_host_reset(mock_gethostbyname_ex, ['10.10.10.10', '11.11.11.11'])
+
+            await client_async_predict(c)
+            assert_n_connections(c, 2)
+
+            await client_async_predict(c)
+            await client_async_predict(c)
+            await client_async_predict(c)
+            await client_async_predict(c)
+            await client_async_predict(c)
+
+            assert c._async_stubs[0].Predict.call_count == 3
+            assert c._async_stubs[1].Predict.call_count == 3
+
+            mock_host_reset(mock_gethostbyname_ex, ['10.10.10.10', '11.11.11.11', '12.12.12.12'])
+            await client_async_predict(c)
+
+            assert c._async_stubs[0].Predict.call_count == 3
+            assert c._async_stubs[1].Predict.call_count == 3
+            assert c._async_stubs[2].Predict.call_count == 1
+
+            async def bar(client):
+                while True:
+                    n = random.randint(1, 5)
+                    await aio.gather(*[client_async_predict(client) for _ in range(n)])
+                    await aio.sleep(random.random())
+
+            async def foo(client, mock_gethostbyname_ex):
+                while True:
+                    mock_host_reset(
+                        mock_gethostbyname_ex,
+                        [str(random.randint(0, 1000)) for _ in range(random.randint(1, 5))],
+                    )
+                    await aio.sleep(random.random() + 0.5)
+
+            t = aio.ensure_future(aio.gather(bar(c), foo(c, mock_gethostbyname_ex)))
+            await aio.sleep(5)
+            t.cancel()
+            try:
+                await t
+            except aio.CancelledError:
+                pass

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -79,6 +79,12 @@ async def test_load_balancing():
         created_stubs.clear()
         created_async_stubs.clear()
 
+    def assert_n_connections(n):
+        assert_n_unique_mocks(created_grpc_channels, 'target', n)
+        assert_n_unique_mocks(created_grpclib_channels, 'addr', n)
+        assert_n_unique_mocks(created_stubs, 'channel', n)
+        assert_n_unique_mocks(created_async_stubs, 'channel', n)
+
     with patch('socket.gethostbyname_ex') as mock_gethostbyname_ex:
         with patch('serving_utils.client.Channel',
                    side_effect=create_a_fake_grpclib_channel), \
@@ -97,10 +103,7 @@ async def test_load_balancing():
             mock_gethostbyname_ex.return_value = ('localhost', [], ['1.2.3.4'])
 
             c = Client(host='localhost', port=9999)
-            assert_n_unique_mocks(created_grpc_channels, 'target', 1)
-            assert_n_unique_mocks(created_grpclib_channels, 'addr', 1)
-            assert_n_unique_mocks(created_stubs, 'channel', 1)
-            assert_n_unique_mocks(created_async_stubs, 'channel', 1)
+            assert_n_connections(1)
 
             created_async_stubs[0].Predict.assert_not_awaited()
 
@@ -114,10 +117,7 @@ async def test_load_balancing():
 
             c = Client(host='localhost', port=9999)
 
-            assert_n_unique_mocks(created_grpc_channels, 'target', 2)
-            assert_n_unique_mocks(created_grpclib_channels, 'addr', 2)
-            assert_n_unique_mocks(created_stubs, 'channel', 2)
-            assert_n_unique_mocks(created_async_stubs, 'channel', 2)
+            assert_n_connections(2)
 
             await client_async_predict(c)
             await client_async_predict(c)
@@ -132,10 +132,7 @@ async def test_load_balancing():
 
             c = Client(host='localhost', port=9999)
 
-            assert_n_unique_mocks(created_grpc_channels, 'target', 3)
-            assert_n_unique_mocks(created_grpclib_channels, 'addr', 3)
-            assert_n_unique_mocks(created_stubs, 'channel', 3)
-            assert_n_unique_mocks(created_async_stubs, 'channel', 3)
+            assert_n_connections(3)
 
             await client_async_predict(c)
             await client_async_predict(c)

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -93,7 +93,8 @@ async def test_load_balancing():
             patch.object(Client,
                          '_check_address_health'):
 
-            mock_gethostbyname_ex.return_value=('localhost', [], ['1.2.3.4'])
+            # Case: Host name resolves to 1 IP address
+            mock_gethostbyname_ex.return_value = ('localhost', [], ['1.2.3.4'])
 
             c = Client(host='localhost', port=9999)
             assert_n_unique_mocks(created_grpc_channels, 'target', 1)
@@ -102,15 +103,15 @@ async def test_load_balancing():
             assert_n_unique_mocks(created_async_stubs, 'channel', 1)
 
             created_async_stubs[0].Predict.assert_not_awaited()
-           
-            await client_async_predict(c) 
+
+            await client_async_predict(c)
 
             created_async_stubs[0].Predict.assert_awaited()
 
-
+            # Case: Host name resolves to 2 IP addresses
             clear_created()
             mock_gethostbyname_ex.return_value = ('localhost', [], ['1.2.3.4', '5.6.7.8'])
-            
+
             c = Client(host='localhost', port=9999)
 
             assert_n_unique_mocks(created_grpc_channels, 'target', 2)
@@ -124,6 +125,7 @@ async def test_load_balancing():
             created_async_stubs[0].Predict.assert_awaited()
             created_async_stubs[1].Predict.assert_awaited()
 
+            # Case: Host name resolves to 3 IP address
             clear_created()
             mock_gethostbyname_ex.return_value = (
                 'localhost', [], ['1.2.3.4', '5.6.7.8', '9.10.11.12'])

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -227,7 +227,7 @@ async def test_retrying():
                         await client_async_predict(c)
                     except Exception:
                         pass
-                assert m.call_count == n_trys
+                assert m.call_count >= n_trys
 
                 with patch.object(
                         Client,
@@ -239,7 +239,7 @@ async def test_retrying():
                         client_predict(c)
                     except Exception:
                         pass
-                assert m.call_count == n_trys
+                assert m.call_count >= n_trys
 
 
 @pytest.mark.asyncio

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -8,32 +8,74 @@ import numpy as np
 from serving_utils import PredictInput
 
 
+req_data = [
+    PredictInput(name='a', value=np.int16(2)),
+    PredictInput(name='b', value=np.int16(3)),
+]
+output_names = ['c']
+model_name = 'test_model'
+
+
+def client_predict(c):
+    c.predict(
+        data=req_data,
+        output_names=output_names,
+        model_name=model_name,
+        model_signature_name='test',
+    )
+
+
+async def client_async_predict(c):
+    await c.async_predict(
+        data=req_data,
+        output_names=output_names,
+        model_name=model_name,
+        model_signature_name='test',
+    )
+
+
 @pytest.mark.asyncio
 async def test_load_balancing():
 
-    created_channels = []
-    created_async_stubs = []
+    created_grpc_channels = []
+    created_grpclib_channels = []
     created_stubs = []
+    created_async_stubs = []
 
-    def create_a_fake_channel(*_, **__):
-        m = mock.MagicMock()
-        created_channels.append(m)
+    def create_a_fake_grpclib_channel(addr, port, loop):
+        m = mock.MagicMock(name=f"{addr}:{port}")
+        created_grpclib_channels.append(m)
         return m
 
-    def create_a_fake_async_stub(_):
-        m = mock.MagicMock()
+    def create_a_fake_grpc_channel(target, *_, **__):
+        m = mock.MagicMock(name=target)
+        created_grpc_channels.append(m)
+        return m
+
+    def create_a_fake_async_stub(*args, **kwargs):
+        m = mock.MagicMock(name=f"async stub {args} {kwargs}")
         m.Predict = CoroutineMock()
         created_async_stubs.append(m)
         return m
 
-    def create_a_fake_stub(_):
-        m = mock.MagicMock()
+    def create_a_fake_stub(*args, **kwargs):
+        m = mock.MagicMock(name=f"stub {args} {kwargs}")
         created_stubs.append(m)
         return m
 
-    with patch('socket.gethostbyname_ex', return_value=('hostname', [], ['1.2.3.4'])):
+    def clear_created():
+        created_grpc_channels.clear()
+        created_grpclib_channels.clear()
+        created_stubs.clear()
+        created_async_stubs.clear()
+
+    with patch('socket.gethostbyname_ex') as mock_gethostbyname_ex:
         with patch('serving_utils.client.Channel',
-                   side_effect=create_a_fake_channel), \
+                   side_effect=create_a_fake_grpclib_channel), \
+            patch('serving_utils.client.grpc.secure_channel',
+                  side_effect=create_a_fake_grpc_channel), \
+            patch('serving_utils.client.grpc.insecure_channel',
+                  side_effect=create_a_fake_grpc_channel), \
             patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
                   side_effect=create_a_fake_async_stub), \
             patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
@@ -41,125 +83,56 @@ async def test_load_balancing():
             patch.object(Client,
                          '_check_address_health'):
 
-            c = Client('127.0.0.1:9999')
-            req_data = [
-                PredictInput(name='a', value=np.int16(2)),
-                PredictInput(name='b', value=np.int16(3)),
-            ]
-            output_names = ['c']
-            model_name = 'test_model'
+            mock_gethostbyname_ex.return_value=('localhost', [], ['1.2.3.4'])
 
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-
-            assert len(created_channels) == 1
+            c = Client('localhost:9999')
+            assert len(created_grpc_channels) == 1
+            assert len(created_grpclib_channels) == 1
+            assert len(created_stubs) == 1
             assert len(created_async_stubs) == 1
+
+            created_async_stubs[0].Predict.assert_not_awaited()
+           
+            await client_async_predict(c) 
+
             created_async_stubs[0].Predict.assert_awaited()
 
-    created_channels.clear()
-    created_async_stubs.clear()
-    created_stubs.clear()
 
-    with patch('socket.gethostbyname_ex', return_value=('hostname', [], ['1.2.3.4', '5.6.7.8'])):
-        with patch('serving_utils.client.Channel',
-                   side_effect=create_a_fake_channel), \
-            patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
-                  side_effect=create_a_fake_async_stub), \
-            patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
-                  side_effect=create_a_fake_stub), \
-            patch.object(Client,
-                         '_check_address_health'):
-
-            c = Client('127.0.0.1:9999')
-            req_data = [
-                PredictInput(name='a', value=np.int16(2)),
-                PredictInput(name='b', value=np.int16(3)),
-            ]
-            output_names = ['c']
-            model_name = 'test_model'
-
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-
-            assert len(created_channels) == 2
+            clear_created()
+            mock_gethostbyname_ex.return_value = ('localhost', [], ['1.2.3.4', '5.6.7.8'])
+            
+            c = Client('localhost:9999')
+            assert len(created_grpc_channels) == 2
+            assert len(created_grpclib_channels) == 2
+            assert len(created_stubs) == 2
             assert len(created_async_stubs) == 2
+
+            await client_async_predict(c)
+            await client_async_predict(c)
+
             created_async_stubs[0].Predict.assert_awaited()
             created_async_stubs[1].Predict.assert_awaited()
 
-    created_channels.clear()
-    created_async_stubs.clear()
-    created_stubs.clear()
+            clear_created()
+            mock_gethostbyname_ex.return_value = (
+                'localhost', [], ['1.2.3.4', '5.6.7.8', '9.10.11.12'])
 
-    with patch('socket.gethostbyname_ex',
-               return_value=('hostname', [], ['1.2.3.4', '5.6.7.8', '9.10.11.12'])):
-        with patch('serving_utils.client.Channel',
-                   side_effect=create_a_fake_channel), \
-            patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
-                  side_effect=create_a_fake_async_stub), \
-            patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
-                  side_effect=create_a_fake_stub), \
-            patch.object(Client,
-                         '_check_address_health'):
-
-            c = Client('127.0.0.1:9999')
-            req_data = [
-                PredictInput(name='a', value=np.int16(2)),
-                PredictInput(name='b', value=np.int16(3)),
-            ]
-            output_names = ['c']
-            model_name = 'test_model'
-
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-
-            assert len(created_channels) == 3
+            c = Client('localhost:9999')
+            assert len(created_grpc_channels) == 3
+            assert len(created_grpclib_channels) == 3
+            assert len(created_stubs) == 3
             assert len(created_async_stubs) == 3
+
+            await client_async_predict(c)
+            await client_async_predict(c)
+            await client_async_predict(c)
+
             created_async_stubs[0].Predict.assert_awaited()
             created_async_stubs[1].Predict.assert_awaited()
             created_async_stubs[2].Predict.assert_awaited()
 
-            c.predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
-            await c.async_predict(
-                data=req_data,
-                output_names=output_names,
-                model_name=model_name,
-                model_signature_name='test',
-            )
+            client_predict(c)
+            await client_async_predict(c)
 
             assert created_stubs[0].Predict.call_count == 1
             assert created_async_stubs[1].Predict.await_count == 2

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -1,0 +1,165 @@
+import pytest
+from unittest import mock
+from asynctest import CoroutineMock
+from unittest.mock import patch
+from ..client import Client
+
+import numpy as np
+from serving_utils import PredictInput
+
+
+@pytest.mark.asyncio
+async def test_load_balancing():
+
+    created_channels = []
+    created_async_stubs = []
+    created_stubs = []
+
+    def create_a_fake_channel(*_, **__):
+        m = mock.MagicMock()
+        created_channels.append(m)
+        return m
+
+    def create_a_fake_async_stub(_):
+        m = mock.MagicMock()
+        m.Predict = CoroutineMock()
+        created_async_stubs.append(m)
+        return m
+
+    def create_a_fake_stub(_):
+        m = mock.MagicMock()
+        created_stubs.append(m)
+        return m
+
+    with patch('socket.gethostbyname_ex', return_value=('hostname', [], ['1.2.3.4'])):
+        with patch('serving_utils.client.Channel',
+                   side_effect=create_a_fake_channel), \
+            patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_async_stub), \
+            patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_stub), \
+            patch.object(Client,
+                         '_check_address_health'):
+
+            c = Client('127.0.0.1:9999')
+            req_data = [
+                PredictInput(name='a', value=np.int16(2)),
+                PredictInput(name='b', value=np.int16(3)),
+            ]
+            output_names = ['c']
+            model_name = 'test_model'
+
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+
+            assert len(created_channels) == 1
+            assert len(created_async_stubs) == 1
+            created_async_stubs[0].Predict.assert_awaited()
+
+    created_channels.clear()
+    created_async_stubs.clear()
+    created_stubs.clear()
+
+    with patch('socket.gethostbyname_ex', return_value=('hostname', [], ['1.2.3.4', '5.6.7.8'])):
+        with patch('serving_utils.client.Channel',
+                   side_effect=create_a_fake_channel), \
+            patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_async_stub), \
+            patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_stub), \
+            patch.object(Client,
+                         '_check_address_health'):
+
+            c = Client('127.0.0.1:9999')
+            req_data = [
+                PredictInput(name='a', value=np.int16(2)),
+                PredictInput(name='b', value=np.int16(3)),
+            ]
+            output_names = ['c']
+            model_name = 'test_model'
+
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+
+            assert len(created_channels) == 2
+            assert len(created_async_stubs) == 2
+            created_async_stubs[0].Predict.assert_awaited()
+            created_async_stubs[1].Predict.assert_awaited()
+
+    created_channels.clear()
+    created_async_stubs.clear()
+    created_stubs.clear()
+
+    with patch('socket.gethostbyname_ex',
+               return_value=('hostname', [], ['1.2.3.4', '5.6.7.8', '9.10.11.12'])):
+        with patch('serving_utils.client.Channel',
+                   side_effect=create_a_fake_channel), \
+            patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_async_stub), \
+            patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
+                  side_effect=create_a_fake_stub), \
+            patch.object(Client,
+                         '_check_address_health'):
+
+            c = Client('127.0.0.1:9999')
+            req_data = [
+                PredictInput(name='a', value=np.int16(2)),
+                PredictInput(name='b', value=np.int16(3)),
+            ]
+            output_names = ['c']
+            model_name = 'test_model'
+
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+
+            assert len(created_channels) == 3
+            assert len(created_async_stubs) == 3
+            created_async_stubs[0].Predict.assert_awaited()
+            created_async_stubs[1].Predict.assert_awaited()
+            created_async_stubs[2].Predict.assert_awaited()
+
+            c.predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+            await c.async_predict(
+                data=req_data,
+                output_names=output_names,
+                model_name=model_name,
+                model_signature_name='test',
+            )
+
+            assert created_stubs[0].Predict.call_count == 1
+            assert created_async_stubs[1].Predict.await_count == 2

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -339,7 +339,7 @@ async def test_server_reset_handling():
             await client_async_predict(c)
             await client_async_predict(c)
 
-            conns = dict(c._pool._list)
+            conns = c._pool._container
             assert conns['10.10.10.10'].async_stub.Predict.await_count == 3
             assert conns['11.11.11.11'].async_stub.Predict.await_count == 3
 
@@ -347,7 +347,7 @@ async def test_server_reset_handling():
             mock_host_reset(mock_gethostbyname_ex, ['10.10.10.10', '11.11.11.11', '12.12.12.12'])
             await client_async_predict(c)
 
-            conns = dict(c._pool._list)
+            conns = c._pool._container
             assert conns['10.10.10.10'].async_stub.Predict.await_count == 3
             assert conns['11.11.11.11'].async_stub.Predict.await_count == 3
             assert conns['12.12.12.12'].async_stub.Predict.await_count == 1
@@ -360,7 +360,7 @@ async def test_server_reset_handling():
             await client_async_predict(c)
             await client_async_predict(c)
 
-            conns = dict(c._pool._list)
+            conns = c._pool._container
             assert conns['10.10.10.10'].async_stub.Predict.await_count == 3
             assert conns['11.11.11.11'].async_stub.Predict.await_count == 3
             assert conns['13.13.13.13'].async_stub.Predict.await_count == 1

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -100,9 +100,7 @@ async def test_load_balancing():
             patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
                   side_effect=create_a_fake_async_stub), \
             patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
-                  side_effect=create_a_fake_stub), \
-            patch.object(Client,
-                         '_check_address_health'):
+                  side_effect=create_a_fake_stub):
 
             # Case: Host name resolves to 1 IP address
             mock_gethostbyname_ex.return_value = ('localhost', [], ['1.2.3.4'])
@@ -219,9 +217,7 @@ async def test_server_reset_handling():
             patch('serving_utils.client.prediction_service_grpc.PredictionServiceStub',
                   side_effect=create_a_fake_async_stub), \
             patch('serving_utils.client.prediction_service_pb2_grpc.PredictionServiceStub',
-                  side_effect=create_a_fake_stub), \
-            patch.object(Client,
-                         '_check_address_health'):
+                  side_effect=create_a_fake_stub):
 
             # Case: Host name resolves to 0 IP addresses
             mock_host_reset(mock_gethostbyname_ex, [])

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -267,8 +267,10 @@ async def test_server_reset_handling():
             assert conns['12.12.12.12'].async_stub.Predict.await_count == 1
 
             # Case: Host reset, 1 IP removed and 2 new IPs added
-            mock_host_reset(mock_gethostbyname_ex,
-                ['10.10.10.10', '11.11.11.11', '13.13.13.13', '14.14.14.14'])
+            mock_host_reset(
+                mock_gethostbyname_ex,
+                ['10.10.10.10', '11.11.11.11', '13.13.13.13', '14.14.14.14'],
+            )
             await client_async_predict(c)
             await client_async_predict(c)
 

--- a/serving_utils/tests/test_round_robin_map.py
+++ b/serving_utils/tests/test_round_robin_map.py
@@ -1,0 +1,46 @@
+from .. import round_robin_map
+
+
+def test_RoundRobinMap():
+    pool = round_robin_map.RoundRobinMap()
+
+    assert len(pool) == 0
+
+    pool['a'] = 'abc'
+    assert len(pool) == 1
+
+    assert next(iter(pool)) == ('a', 'abc')
+    assert next(iter(pool)) == ('a', 'abc')
+    assert next(iter(pool)) == ('a', 'abc')
+
+    pool['b'] = 'bbc'
+    assert len(pool) == 2
+
+    assert next(iter(pool)) == ('b', 'bbc')
+    assert next(iter(pool)) == ('a', 'abc')
+    assert next(iter(pool)) == ('b', 'bbc')
+    assert next(iter(pool)) == ('a', 'abc')
+
+    pool['c'] = 'ccc'
+
+    assert next(iter(pool)) == ('c', 'ccc')
+    assert next(iter(pool)) == ('b', 'bbc')
+    assert next(iter(pool)) == ('a', 'abc')
+
+    del pool['c']
+    assert next(iter(pool)) == ('b', 'bbc')
+    assert next(iter(pool)) == ('a', 'abc')
+
+    assert next(iter(pool)) == ('b', 'bbc')
+    pool['b'] = 1
+    assert next(iter(pool)) == ('b', 1)
+    pool['b'] = 1
+    assert next(iter(pool)) == ('b', 1)
+    pool['b'] = 1
+    assert next(iter(pool)) == ('b', 1)
+
+    assert next(iter(pool)) == ('a', 'abc')
+    pool['b']
+    assert next(iter(pool)) == ('a', 'abc')
+    pool['b']
+    assert next(iter(pool)) == ('a', 'abc')

--- a/serving_utils/tests/test_round_robin_map.py
+++ b/serving_utils/tests/test_round_robin_map.py
@@ -5,9 +5,11 @@ def test_RoundRobinMap():
     pool = round_robin_map.RoundRobinMap()
 
     assert len(pool) == 0
+    assert pool.keys() == set()
 
     pool['a'] = 'abc'
     assert len(pool) == 1
+    assert pool.keys() == {'a'}
 
     assert next(iter(pool)) == ('a', 'abc')
     assert next(iter(pool)) == ('a', 'abc')
@@ -15,6 +17,7 @@ def test_RoundRobinMap():
 
     pool['b'] = 'bbc'
     assert len(pool) == 2
+    assert pool.keys() == {'a', 'b'}
 
     assert next(iter(pool)) == ('b', 'bbc')
     assert next(iter(pool)) == ('a', 'abc')
@@ -22,12 +25,15 @@ def test_RoundRobinMap():
     assert next(iter(pool)) == ('a', 'abc')
 
     pool['c'] = 'ccc'
+    assert pool.keys() == {'a', 'b', 'c'}
 
     assert next(iter(pool)) == ('c', 'ccc')
     assert next(iter(pool)) == ('b', 'bbc')
     assert next(iter(pool)) == ('a', 'abc')
 
     del pool['c']
+    assert pool.keys() == {'a', 'b'}
+
     assert next(iter(pool)) == ('b', 'bbc')
     assert next(iter(pool)) == ('a', 'abc')
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,7 +23,8 @@ async def test_client():
             time.sleep(1)
             try:
                 client = Client(
-                    addr=f"localhost:{serving_port}",
+                    host="localhost",
+                    port=serving_port,
                 )
                 client.predict(None, output_names='wrong_model', model_signature_name='test')
                 break
@@ -37,7 +38,8 @@ async def test_client():
     clients = []
     for serving_port in test_serving_ports:
         clients.append(Client(
-            addr=f"localhost:{serving_port}",
+            host="localhost",
+            port=serving_port,
         ))
 
     req_data = [
@@ -78,5 +80,6 @@ async def test_not_exist_addr():
     for serving_port in test_serving_ports:
         with pytest.raises(grpc._channel._Rendezvous):
             Client(
-                addr=f"localhost:{serving_port}",
+                host="localhost",
+                port=serving_port,
             )


### PR DESCRIPTION
- [x] Add round-robin load balancing to `Client`. When `host` resolves to n ip-addresses, load balance between all n addresses.
- [x] Handle hostname resolution changes (like when pods are killed and new pods are made by k8s)

Breaking change: `Client` now takes `host` and `port` instead of `addr`