### PR TITLE
Simpler input data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,10 @@ loader.load(new_sess)  # load the saved model into new session
 
 2. Client
 ```python
-from serving_utils import Client, PredictInput
-
+from serving_utils import Client
 client = Client(host="localhost", port=8500, n_trys=3)
 client.predict(
-    [PredictInput(name='input', value=np.ones(1, 10))],
+    {'input': np.ones(1, 10)},
     output_names=['output'],
     model_signature_name='predict',
 )

--- a/serving_utils/client.py
+++ b/serving_utils/client.py
@@ -1,7 +1,7 @@
 from functools import partial
 import logging
 import socket
-from typing import List
+from typing import List, Union, Mapping
 
 import asyncio
 from collections import namedtuple
@@ -33,6 +33,8 @@ def copy_message(src, dst):
 
 
 PredictInput = namedtuple('PredictInput', ['name', 'value'])
+ORIGINAL_DATA_TYPE = List[PredictInput]
+NEW_DATA_TYPE = Mapping[str, 'np.ndarray']
 
 
 class Connection:
@@ -164,8 +166,8 @@ class Client:
 
     @staticmethod
     def _predict_request(
-            data,
-            model_name,
+            data: Union[ORIGINAL_DATA_TYPE, NEW_DATA_TYPE],
+            model_name: str,
             output_names=None,
             model_signature_name=None,
         ):
@@ -175,7 +177,14 @@ class Client:
             req.model_spec.signature_name = model_signature_name
 
         for datum in data:
-            copy_message(tf.make_tensor_proto(datum.value), req.inputs[datum.name])
+            if isinstance(datum, PredictInput):
+                # old way to pass input
+                name = datum.name
+                value = datum.value
+            else:
+                name = datum
+                value = data[datum]
+            copy_message(tf.make_tensor_proto(value), req.inputs[name])
         if output_names is not None:
             for output_name in output_names:
                 req.output_filter.append(output_name)

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -14,10 +14,10 @@ import numpy as np
 from serving_utils import PredictInput
 
 
-req_data = [
-    PredictInput(name='a', value=np.int16(2)),
-    PredictInput(name='b', value=np.int16(3)),
-]
+req_data = {
+    'a': np.int16(2),
+    'b': np.int16(3)
+}
 output_names = ['c']
 model_name = 'test_model'
 

--- a/serving_utils/tests/test_client.py
+++ b/serving_utils/tests/test_client.py
@@ -8,15 +8,14 @@ from unittest.mock import patch
 import grpc
 import grpc._channel
 import grpclib
-from ..client import Client, RetryFailed, Connection
-
 import numpy as np
-from serving_utils import PredictInput
+
+from ..client import Client, RetryFailed, Connection
 
 
 req_data = {
     'a': np.int16(2),
-    'b': np.int16(3)
+    'b': np.int16(3),
 }
 output_names = ['c']
 model_name = 'test_model'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -78,3 +78,29 @@ async def test_client():
         )
 
         assert actual_output == expected_output
+
+    # test client predict with simpler format
+    req_data = {
+        'a': np.int16(2),
+        'b': np.int16(3)
+    }
+    output_names = ['c']
+    expected_output = {'c': 8}  # c = a + 2 * b
+    for client in clients:
+        actual_output = client.predict(
+            data=req_data,
+            output_names=output_names,
+            model_name=model_name,
+            model_signature_name='test',
+        )
+
+        assert actual_output == expected_output
+
+        actual_output = await client.async_predict(
+            data=req_data,
+            output_names=output_names,
+            model_name=model_name,
+            model_signature_name='test',
+        )
+
+        assert actual_output == expected_output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -82,7 +82,7 @@ async def test_client():
     # test client predict with simpler format
     req_data = {
         'a': np.int16(2),
-        'b': np.int16(3)
+        'b': np.int16(3),
     }
     output_names = ['c']
     expected_output = {'c': 8}  # c = a + 2 * b


### PR DESCRIPTION
from 
```python
from serving_utils import Client, PredictInput

client = Client(host="localhost", port=8500, n_trys=3)
client.predict(
    [PredictInput(name='input', value=np.ones(1, 10))],
    output_names=['output'],
    model_signature_name='predict',
)
```

to
```python
from serving_utils import Client
client = Client(host="localhost", port=8500, n_trys=3)
client.predict(
    {'input': np.ones(1, 10)},
    output_names=['output'],
    model_signature_name='predict',
)
```